### PR TITLE
adjust script path names in the Dockerfile so that no additional options are required to build the docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build image
-        run: docker build . --file docker/Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+        run: docker build docker --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,9 +25,9 @@ RUN apt-get update && apt-get -y full-upgrade && \
     libzmq3-dev
 
 WORKDIR /tmp/mdt-dialout-collector
-COPY docker/scripts/grpc.sh scripts/
-COPY docker/scripts/mdt_dialout_collector.sh scripts/
-COPY docker/scripts/mdt_dialout_collector.conf /etc/opt/mdt-dialout-collector/
+COPY scripts/grpc.sh scripts/
+COPY scripts/mdt_dialout_collector.sh scripts/
+COPY scripts/mdt_dialout_collector.conf /etc/opt/mdt-dialout-collector/
 
 RUN ./scripts/grpc.sh
 RUN rm -rf grpc


### PR DESCRIPTION
Building the docker image fails for me (on rocky linux 8.9). This PR adjusts the script path names in the docker file so that the image build succeeds.