### PR TITLE
install.sh: fix Debian 12 detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -744,6 +744,7 @@ grpc_collector_deploy() {
 
   case "${_os_info}" in
   "Linux debian 11"    | \
+  "Linux debian 12"    | \
   "Linux ubuntu 20.04" | \
   "Linux ubuntu 22.04" | \
   "Linux ubuntu 22.10" | \


### PR DESCRIPTION
The docker image uses Debian stable, which is Debian 12 now. Manually building mdt-dialout-collector inside of the docker image with the install.sh script fails with "Linux debian 12 offcially not supported".