### PR TITLE
Fix Kafka Key and default none ssl verification

### DIFF
--- a/src/dataDelivery/kafka_delivery.cc
+++ b/src/dataDelivery/kafka_delivery.cc
@@ -65,9 +65,10 @@ bool KafkaDelivery::AsyncKafkaProducer(
         kafka::Topic topic = get_topic();
         kafka::Properties properties = get_properties();
 
+	spdlog::get("multi-logger")->debug("[AsyncKafkaProducer] Attempting to send with key: '{}'", peer);
         auto record = kafka::clients::producer::ProducerRecord(
             topic,
-            kafka::Key(peer.c_str()),
+            kafka::Key(peer.c_str(), peer.size()),
             kafka::Value(json_str.c_str(), json_str.size())
             );
 

--- a/src/utils/cfg_handler.cc
+++ b/src/utils/cfg_handler.cc
@@ -1162,14 +1162,14 @@ bool KafkaCfgHandler::lookup_kafka_parameters(const std::string &cfg_path,
                 return false;
             }
         } else {
-            params.insert({"enable_ssl_certificate_verification", "NULL"});
+            params.insert({"enable_ssl_certificate_verification", "false"});
         }
     } else {
         params.insert({"ssl_key_location", "NULL"});
         params.insert({"ssl_key_password", "NULL"});
         params.insert({"ssl_certificate_location", "NULL"});
         params.insert({"ssl_ca_location", "NULL"});
-        params.insert({"enable_ssl_certificate_verification", "NULL"});
+        params.insert({"enable_ssl_certificate_verification", "false"});
     }
 
     return true;


### PR DESCRIPTION
Merge requests consists of two kafka fixes:

1. fix sending messages to kafka using the node_ip as the key, currently NULL
2. fix trying to connect to a none SSL enabled kafka node. Default value is NULL which is not accepted by the Kafka library. Default now false. 